### PR TITLE
Robustified portmapper with exponential backoff, logrus logging, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # portmapper
 
 A portmapper backed by etcd v2.
+
+# Testing
+
+* Set the environmental variable ETCD_ENV="http://etcd-docker-ip"
+* Run ``` docker-compose up ```
+* go test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+etcd:
+  image: quay.io/coreos/etcd:v2.0.8
+  command: -name portmap_test_etcd -advertise-client-urls http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379
+  ports:
+    - 2379:2379
+    - 4001:4001
+

--- a/portmapper_test.go
+++ b/portmapper_test.go
@@ -1,0 +1,74 @@
+package portmapper
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	// IN ALPHABETICAL ORDER
+	validservices = []*Service{
+		&Service{Name: "serviceA", Port: 1},
+		&Service{Name: "serviceB", Port: 499},
+		&Service{Name: "serviceC", Port: 8888},
+		&Service{Name: "serviceD", Port: 65535},
+	}
+	invalidservices = []*Service{
+		&Service{Name: "serviceA", Port: 0},
+		&Service{Name: "serviceB", Port: 65536},
+		&Service{Name: "serviceC", Port: -1},
+		//&Service{Name: "serviceC", Port: 23, Hostname: *(*string)(nil)},
+	}
+)
+
+func Test_RegisterValidServices(t *testing.T) {
+	// register these validservices
+	for i := 0; i < len(validservices); i++ {
+		if Register(validservices[i].Name, validservices[i].Port) != nil {
+			t.Error("error registering %s on port %v", validservices[i].Name, validservices[i].Port)
+		} else {
+			t.Log("successfully registered %s on port %v", validservices[i].Name, validservices[i].Port)
+		}
+	}
+
+	// verify that we have registered these services by getting them from etcd
+	if resultantservices, err := Services(); err == nil {
+		if resultantservices != nil {
+			assert.Equal(t, len(validservices), len(resultantservices))
+
+			for i := 0; i < len(resultantservices); i++ {
+				t.Log("Found service %s on port %v", resultantservices[i].Name, resultantservices[i].Port)
+
+				assert.Equal(t, resultantservices[i].Name, validservices[i].Name)
+				assert.Equal(t, resultantservices[i].Port, validservices[i].Port)
+			}
+		} else {
+			t.Log("Bad news.  Retrieved services list is nil")
+		}
+	} else {
+		t.Error("Error retrieving services: %s", err)
+	}
+
+}
+
+func Test_UnregisterValidServices(t *testing.T) {
+	// register these validservices
+	for i := 0; i < len(validservices); i++ {
+		if Unregister(validservices[i].Name, validservices[i].Port) != nil {
+			t.Error("error unregistering %s on port %v", validservices[i].Name, validservices[i].Port)
+		} else {
+			t.Log("successfully unregistered %s on port %v", validservices[i].Name, validservices[i].Port)
+		}
+	}
+}
+
+func Test_RegisterInvalidServices(t *testing.T) {
+	// register these validservices
+	for i := 0; i < len(invalidservices); i++ {
+		if Register(invalidservices[i].Name, invalidservices[i].Port) != nil {
+			t.Log("error registering INVALID SERVICE %s on port %v", invalidservices[i].Name, invalidservices[i].Port)
+		} else {
+			t.Error("successfully registered INVALID SERVICE %s on port %v", invalidservices[i].Name, invalidservices[i].Port)
+		}
+	}
+}


### PR DESCRIPTION
- Added testing for Unregister, Register, and Services functions
- Added docker-compose for etcd for testing
- Updated to etcd/client (no longer using deprecated go-etcd)
- Added logrus logging
- Updated Readme
